### PR TITLE
Add support for "%s" in bundle name (replaced by hash)

### DIFF
--- a/src/DotsUnited/BundleFu/Bundle.php
+++ b/src/DotsUnited/BundleFu/Bundle.php
@@ -546,6 +546,8 @@ class Bundle
 
         if (null === $name) {
             $name = sprintf('bundle_%s', $this->getCssFileList()->getHash());
+        } elseif (strpos($name, '%s') !== false) {
+            $name = sprintf($name, $this->getCssFileList()->getHash());
         }
 
         return sprintf(
@@ -573,6 +575,8 @@ class Bundle
 
         if (null === $name) {
             $name = sprintf('bundle_%s', $this->getJsFileList()->getHash());
+        } elseif (strpos($name, '%s') !== false) {
+            $name = sprintf($name, $this->getJsFileList()->getHash());
         }
 
         return sprintf(
@@ -606,6 +610,8 @@ class Bundle
 
         if (null === $name) {
             $name = sprintf('bundle_%s', $this->getCssFileList()->getHash());
+        } elseif (strpos($name, '%s') !== false) {
+            $name = sprintf($name, $this->getCssFileList()->getHash());
         }
 
         return sprintf(
@@ -638,6 +644,8 @@ class Bundle
 
         if (null === $name) {
             $name = sprintf('bundle_%s', $this->getJsFileList()->getHash());
+        } elseif (strpos($name, '%s') !== false) {
+            $name = sprintf($name, $this->getJsFileList()->getHash());
         }
 
         return sprintf(


### PR DESCRIPTION
This patch looks for '%s' in a named bundle and replaces it by the
bundles' hash.

This allows to have named bundles, whose path/url changes if the its
content changes.

You might want to refactor this into a getNameForType method (handling
both null values for $name and %s in a regular name).
